### PR TITLE
feat: support approve transfer with operator (breaking change)

### DIFF
--- a/contracts/core/ERC1155CreatorCore.sol
+++ b/contracts/core/ERC1155CreatorCore.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import "../extensions/ERC1155/IERC1155CreatorExtensionApproveTransfer.sol";
+import "../extensions/ERC1155/IERC1155CreatorExtensionApproveTransferV2.sol";
 import "../extensions/ERC1155/IERC1155CreatorExtensionBurnable.sol";
 import "../permissions/ERC1155/IERC1155CreatorMintPermissions.sol";
 import "./IERC1155CreatorCore.sol";
@@ -30,7 +30,7 @@ abstract contract ERC1155CreatorCore is CreatorCore, IERC1155CreatorCore {
      * @dev See {ICreatorCore-setApproveTransferExtension}.
      */
     function setApproveTransferExtension(bool enabled) external override extensionRequired {
-        require(!enabled || ERC165Checker.supportsInterface(msg.sender, type(IERC1155CreatorExtensionApproveTransfer).interfaceId), "Extension must implement IERC1155CreatorExtensionApproveTransfer");
+        require(!enabled || ERC165Checker.supportsInterface(msg.sender, type(IERC1155CreatorExtensionApproveTransferV2).interfaceId), "Extension must implement IERC1155CreatorExtensionApproveTransfer");
         if (_extensionApproveTransfers[msg.sender] != enabled) {
             _extensionApproveTransfers[msg.sender] = enabled;
             emit ExtensionApproveTransferUpdated(msg.sender, enabled);
@@ -85,7 +85,7 @@ abstract contract ERC1155CreatorCore is CreatorCore, IERC1155CreatorCore {
             require(_tokensExtension[tokenIds[i]] == extension, "Mismatched token originators");
         }
         if (_extensionApproveTransfers[extension]) {
-            require(IERC1155CreatorExtensionApproveTransfer(extension).approveTransfer(from, to, tokenIds, amounts), "Extension approval failure");
+            require(IERC1155CreatorExtensionApproveTransferV2(extension).approveTransfer(msg.sender, from, to, tokenIds, amounts), "Extension approval failure");
         }
     }
 

--- a/contracts/core/ERC721CreatorCore.sol
+++ b/contracts/core/ERC721CreatorCore.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import "../extensions/ERC721/IERC721CreatorExtensionApproveTransfer.sol";
+import "../extensions/ERC721/IERC721CreatorExtensionApproveTransferV2.sol";
 import "../extensions/ERC721/IERC721CreatorExtensionBurnable.sol";
 import "../permissions/ERC721/IERC721CreatorMintPermissions.sol";
 import "./IERC721CreatorCore.sol";
@@ -30,7 +30,7 @@ abstract contract ERC721CreatorCore is CreatorCore, IERC721CreatorCore {
      * @dev See {ICreatorCore-setApproveTransferExtension}.
      */
     function setApproveTransferExtension(bool enabled) external override extensionRequired {
-        require(!enabled || ERC165Checker.supportsInterface(msg.sender, type(IERC721CreatorExtensionApproveTransfer).interfaceId), "Extension must implement IERC721CreatorExtensionApproveTransfer");
+        require(!enabled || ERC165Checker.supportsInterface(msg.sender, type(IERC721CreatorExtensionApproveTransferV2).interfaceId), "Extension must implement IERC721CreatorExtensionApproveTransfer");
         if (_extensionApproveTransfers[msg.sender] != enabled) {
             _extensionApproveTransfers[msg.sender] = enabled;
             emit ExtensionApproveTransferUpdated(msg.sender, enabled);
@@ -92,7 +92,7 @@ abstract contract ERC721CreatorCore is CreatorCore, IERC721CreatorCore {
      */
     function _approveTransfer(address from, address to, uint256 tokenId) internal {
        if (_extensionApproveTransfers[_tokensExtension[tokenId]]) {
-           require(IERC721CreatorExtensionApproveTransfer(_tokensExtension[tokenId]).approveTransfer(from, to, tokenId), "ERC721Creator: Extension approval failure");
+           require(IERC721CreatorExtensionApproveTransferV2(_tokensExtension[tokenId]).approveTransfer(msg.sender, from, to, tokenId), "ERC721Creator: Extension approval failure");
        }
     }
 

--- a/contracts/extensions/ERC1155/ERC1155CreatorExtensionApproveTransferV2.sol
+++ b/contracts/extensions/ERC1155/ERC1155CreatorExtensionApproveTransferV2.sol
@@ -8,19 +8,19 @@ import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import "@manifoldxyz/libraries-solidity/contracts/access/AdminControl.sol";
 
 import "../../core/IERC1155CreatorCore.sol";
-import "./IERC1155CreatorExtensionApproveTransfer.sol";
+import "./IERC1155CreatorExtensionApproveTransferV2.sol";
 
 /**
  * @dev Suggested implementation for extensions that require the creator to
  * check with it before a transfer occurs
  */
-abstract contract ERC1155CreatorExtensionApproveTransfer is AdminControl, IERC1155CreatorExtensionApproveTransfer {
+abstract contract ERC1155CreatorExtensionApproveTransfer is AdminControl, IERC1155CreatorExtensionApproveTransferV2 {
 
     /**
      * @dev See {IERC165-supportsInterface}.
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override(AdminControl, IERC165) returns (bool) {
-        return interfaceId == type(IERC1155CreatorExtensionApproveTransfer).interfaceId
+        return interfaceId == type(IERC1155CreatorExtensionApproveTransferV2).interfaceId
             || super.supportsInterface(interfaceId);
     }
 

--- a/contracts/extensions/ERC1155/IERC1155CreatorExtensionApproveTransferV2.sol
+++ b/contracts/extensions/ERC1155/IERC1155CreatorExtensionApproveTransferV2.sol
@@ -9,15 +9,15 @@ import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 /**
  * Implement this if you want your extension to approve a transfer
  */
-interface IERC721CreatorExtensionApproveTransfer is IERC165 {
+interface IERC1155CreatorExtensionApproveTransferV2 is IERC165 {
 
     /**
-     * @dev Set whether or not the creator will check the extension for approval of token transfer
+     * @dev Set whether or not the creator contract will check the extension for approval of token transfer
      */
     function setApproveTransfer(address creator, bool enabled) external;
 
     /**
      * @dev Called by creator contract to approve a transfer
      */
-    function approveTransfer(address from, address to, uint256 tokenId) external returns (bool);
+    function approveTransfer(address operator, address from, address to, uint256[] calldata tokenIds, uint256[] calldata amounts) external returns (bool);
 }

--- a/contracts/extensions/ERC721/ERC721CreatorExtensionApproveTransferV2.sol
+++ b/contracts/extensions/ERC721/ERC721CreatorExtensionApproveTransferV2.sol
@@ -9,19 +9,19 @@ import "@manifoldxyz/libraries-solidity/contracts/access/AdminControl.sol";
 
 import "../../core/IERC721CreatorCore.sol";
 import "./ERC721CreatorExtension.sol";
-import "./IERC721CreatorExtensionApproveTransfer.sol";
+import "./IERC721CreatorExtensionApproveTransferV2.sol";
 
 /**
  * @dev Suggested implementation for extensions that require the creator to
  * check with it before a transfer occurs
  */
-abstract contract ERC721CreatorExtensionApproveTransfer is AdminControl, ERC721CreatorExtension, IERC721CreatorExtensionApproveTransfer {
+abstract contract ERC721CreatorExtensionApproveTransferV2 is AdminControl, ERC721CreatorExtension, IERC721CreatorExtensionApproveTransferV2 {
 
     /**
      * @dev See {IERC165-supportsInterface}.
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override(AdminControl, CreatorExtension, IERC165) returns (bool) {
-        return interfaceId == type(IERC721CreatorExtensionApproveTransfer).interfaceId
+        return interfaceId == type(IERC721CreatorExtensionApproveTransferV2).interfaceId
             || super.supportsInterface(interfaceId);
     }
 

--- a/contracts/extensions/ERC721/IERC721CreatorExtensionApproveTransferV2.sol
+++ b/contracts/extensions/ERC721/IERC721CreatorExtensionApproveTransferV2.sol
@@ -9,15 +9,15 @@ import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 /**
  * Implement this if you want your extension to approve a transfer
  */
-interface IERC1155CreatorExtensionApproveTransfer is IERC165 {
+interface IERC721CreatorExtensionApproveTransferV2 is IERC165 {
 
     /**
-     * @dev Set whether or not the creator contract will check the extension for approval of token transfer
+     * @dev Set whether or not the creator will check the extension for approval of token transfer
      */
     function setApproveTransfer(address creator, bool enabled) external;
 
     /**
      * @dev Called by creator contract to approve a transfer
      */
-    function approveTransfer(address from, address to, uint256[] calldata tokenIds, uint256[] calldata amounts) external returns (bool);
+    function approveTransfer(address operator, address from, address to, uint256 tokenId) external returns (bool);
 }

--- a/contracts/mocks/MockERC721CreatorExtensionOverride.sol
+++ b/contracts/mocks/MockERC721CreatorExtensionOverride.sol
@@ -3,10 +3,10 @@
 pragma solidity ^0.8.0;
 
 import "../core/IERC721CreatorCore.sol";
-import "../extensions/ERC721/ERC721CreatorExtensionApproveTransfer.sol";
+import "../extensions/ERC721/ERC721CreatorExtensionApproveTransferV2.sol";
 import "../extensions/ICreatorExtensionTokenURI.sol";
 
-contract MockERC721CreatorExtensionOverride is ERC721CreatorExtensionApproveTransfer, ICreatorExtensionTokenURI {
+contract MockERC721CreatorExtensionOverride is ERC721CreatorExtensionApproveTransferV2, ICreatorExtensionTokenURI {
 
     bool _approveEnabled;
     string _tokenURI;
@@ -19,7 +19,7 @@ contract MockERC721CreatorExtensionOverride is ERC721CreatorExtensionApproveTran
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721CreatorExtensionApproveTransfer, IERC165) returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721CreatorExtensionApproveTransferV2, IERC165) returns (bool) {
         return interfaceId == type(ICreatorExtensionTokenURI).interfaceId
             || super.supportsInterface(interfaceId);
     }
@@ -36,7 +36,7 @@ contract MockERC721CreatorExtensionOverride is ERC721CreatorExtensionApproveTran
         _tokenURI = uri;
     }
 
-    function approveTransfer(address, address, uint256) external view virtual override returns (bool) {
+    function approveTransfer(address, address, address, uint256) external view virtual override returns (bool) {
         return _approveEnabled;
     }
 


### PR DESCRIPTION
- include operator in approveTransfer
- deprecate support for previous approveTransfer extensions